### PR TITLE
Wrapping setup/teardown code into a BlockStmt

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
@@ -923,9 +923,9 @@ public class CleanerFixerPlugin extends TestPlugin {
         // Note: consider both standard imported version (e.g., @Before) and weird non-imported version (e.g., @org.junit.Before)
         // Only include BeforeClass and Before if in separate classes (for both victim and polluter(s))
         if (!isSameTestClass) {
-            cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.BeforeClass"));
+            cleanerStmts.add(new BlockStmt(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.BeforeClass")));
         }
-        cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.Before"));
+        cleanerStmts.add(new BlockStmt(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.Before")));
         if (!expected) {
             cleanerStmts.addAll(cleanerMethod.body().getStatements());
         } else {
@@ -935,9 +935,9 @@ public class CleanerFixerPlugin extends TestPlugin {
             cleanerStmts.add(new TryStmt(new BlockStmt(cleanerMethod.body().getStatements()), NodeList.nodeList(catchClause), new BlockStmt()));
         }
         // Only include AfterClass and After if in separate classes (for both victim and polluter(s))
-        cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.After"));
+        cleanerStmts.add(new BlockStmt(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.After")));
         if (!isSameTestClass) {
-            cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.AfterClass"));
+            cleanerStmts.add(new BlockStmt(getCodeFromAnnotatedMethod(cleanerMethod.getClassName(), cleanerMethod.javaFile(), "@org.junit.AfterClass")));
         }
 
         return cleanerStmts;


### PR DESCRIPTION
Instead of adding all of the individual statements from a setup/teardown into the helper method for minimizing, this pull request wraps those statements into blocks. Sometimes the setup/teardown methods introduce variables that are declared in the cleaner test itself, so combining them can lead to compilation errors.